### PR TITLE
Matching of the GUI to the host system

### DIFF
--- a/de.willuhn.Jameica.yaml
+++ b/de.willuhn.Jameica.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --env=PATH=/usr/bin:/app/bin:/app/jre/bin
   - --env=JAVA_HOME=/app/jre
   - --filesystem=home:rw
+  - --filesystem=xdg-config/gtk-3.0:ro
 modules:
   - name: openjdk
     buildsystem: simple


### PR DESCRIPTION
By adding read-only access of the application to the gtk-3.0 directory, the theme of the application match the installed theme of the host system (verified on Fedora 36 with KDE). It is no longer necessary to install theme (e.g. Breeze Dark) in flatpak.