### PR TITLE
Update Java version to OpenJDK 17

### DIFF
--- a/de.willuhn.Jameica.yaml
+++ b/de.willuhn.Jameica.yaml
@@ -4,7 +4,7 @@ runtime: org.gnome.Platform
 runtime-version: '42'
 sdk: org.gnome.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk11
+  - org.freedesktop.Sdk.Extension.openjdk17
 command: jameica-wrapper.sh
 finish-args:
   - --socket=x11
@@ -20,7 +20,7 @@ modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk11/install.sh
+      - /usr/lib/sdk/openjdk17/install.sh
 
   - name: jameica
     buildsystem: simple


### PR DESCRIPTION
Since Jameica supports Java 18+ since version 2.10.2 it is possible to update the used version of Java to the latest LTS version.

Solves #14 