### PR TITLE
Updating the GNOME runtime to version 43

### DIFF
--- a/de.willuhn.Jameica.yaml
+++ b/de.willuhn.Jameica.yaml
@@ -1,7 +1,7 @@
 app-id: de.willuhn.Jameica
 default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '43'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk11

--- a/de.willuhn.Jameica.yaml
+++ b/de.willuhn.Jameica.yaml
@@ -9,7 +9,6 @@ command: jameica-wrapper.sh
 finish-args:
   - --socket=x11
   - --socket=wayland
-  # - --socket=session-bus
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.SessionManager

--- a/de.willuhn.Jameica.yaml
+++ b/de.willuhn.Jameica.yaml
@@ -9,7 +9,10 @@ command: jameica-wrapper.sh
 finish-args:
   - --socket=x11
   - --socket=wayland
-  - --socket=session-bus
+  # - --socket=session-bus
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.gnome.SessionManager
   - --share=ipc
   - --share=network
   - --device=dri


### PR DESCRIPTION
GNOME runtime is available in version 43 since a while. Using the application with the runtime works fine on Fedora 36 (x86_64).