### PR TITLE
issue-21: rollback to gnome platform 42

### DIFF
--- a/de.willuhn.Jameica.yaml
+++ b/de.willuhn.Jameica.yaml
@@ -1,7 +1,7 @@
 app-id: de.willuhn.Jameica
 default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: '43'
+runtime-version: '42'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17


### PR DESCRIPTION
rollback to gnome platform 42 since version 43 is missing webkitgtk library