### PR TITLE
Jameica 2.10.3 released

### DIFF
--- a/de.willuhn.Jameica.metainfo.xml
+++ b/de.willuhn.Jameica.metainfo.xml
@@ -31,6 +31,9 @@
   </description>
   <url type="homepage">https://www.willuhn.de/products/jameica//</url>
   <releases>
+    <release date="2023-01-25" version="2.10.3">
+      <url>https://willuhn.de/wiki/doku.php?id=hibiscus_2.10#jameica_2103_25012023</url>
+    </release>
     <release date="2022-05-03" version="2.10.2">
       <url>https://willuhn.de/wiki/doku.php?id=hibiscus_2.10#jameica_2102_03052022</url>
     </release>

--- a/de.willuhn.Jameica.yaml
+++ b/de.willuhn.Jameica.yaml
@@ -36,8 +36,8 @@ modules:
       - install -Dm644 -t /app/share/applications de.willuhn.Jameica.desktop
     sources:
       - type: archive
-        url: https://willuhn.de/products/jameica/releases/current/jameica/jameica-linux64-2.10.2.zip
-        sha1: bea9dd098792c363957b7042f3fa88e9c5784c71
+        url: https://willuhn.de/products/jameica/releases/current/jameica/jameica-linux64-2.10.3.zip
+        sha256: b72dfdc4ce000c23c8924c7dadc644285dad0aee9fb6f11fc431b284c6138490
         dest: jameica
       - type: file
         path: jameica-wrapper.sh


### PR DESCRIPTION
Version 2.10.3 of Jameica was released by Olaf on 25th January, 2023. This updates the flatpak to this version