### PR TITLE
Jameica 2.10.4

### DIFF
--- a/de.willuhn.Jameica.metainfo.xml
+++ b/de.willuhn.Jameica.metainfo.xml
@@ -31,6 +31,9 @@
   </description>
   <url type="homepage">https://www.willuhn.de/products/jameica//</url>
   <releases>
+    <release date="2023-04-14" version="2.10.4">
+      <url>https://willuhn.de/wiki/doku.php?id=hibiscus_2.10#jameica_2104_14042023</url>
+    </release>
     <release date="2023-01-25" version="2.10.3">
       <url>https://willuhn.de/wiki/doku.php?id=hibiscus_2.10#jameica_2103_25012023</url>
     </release>

--- a/de.willuhn.Jameica.yaml
+++ b/de.willuhn.Jameica.yaml
@@ -36,8 +36,8 @@ modules:
       - install -Dm644 -t /app/share/applications de.willuhn.Jameica.desktop
     sources:
       - type: archive
-        url: https://willuhn.de/products/jameica/releases/current/jameica/jameica-linux64-2.10.3.zip
-        sha256: b72dfdc4ce000c23c8924c7dadc644285dad0aee9fb6f11fc431b284c6138490
+        url: https://willuhn.de/products/jameica/releases/current/jameica/jameica-linux64-2.10.4.zip
+        sha256: d6b16527a37db1de54a77f50f92fcac5e2a765b69b7ab0986f4233d6dbf5fa2d
         dest: jameica
       - type: file
         path: jameica-wrapper.sh


### PR DESCRIPTION
Olaf Willuhn released version 2.10.4 of Jameica on 14. April 2023. This PR updates the flatpak to use the latest release.